### PR TITLE
Also set user flag when token is set for pyPolarionCli.

### DIFF
--- a/src/pyMetricCli/polarion.py
+++ b/src/pyMetricCli/polarion.py
@@ -149,7 +149,8 @@ class Polarion:  # pylint: disable=too-few-public-methods
 
         # Add token if available. pyPolarionCli will use it instead of the password if provided.
         if token:
-            command_list += ["--token", token]
+            command_list += ["--user", username,
+                             "--token", token]
         else:
             command_list += ["--user", username,
                              "--password", password]

--- a/src/pyMetricCli/polarion.py
+++ b/src/pyMetricCli/polarion.py
@@ -148,12 +148,11 @@ class Polarion:  # pylint: disable=too-few-public-methods
         command_list: list = []
 
         # Add token if available. pyPolarionCli will use it instead of the password if provided.
+        command_list += ["--user", username]
         if token:
-            command_list += ["--user", username,
-                             "--token", token]
+            command_list += ["--token", token]
         else:
-            command_list += ["--user", username,
-                             "--password", password]
+            command_list += ["--password", password]
 
         command_list += ["--server", server,
                          "search",


### PR DESCRIPTION
#21 describes the problem.

A -u flag MUST be supplied currently.

Can we ensure the "username" value is valid?
Or do we need to set a dummy username if the username property is not set in the profile?